### PR TITLE
Override GeneratePkgDef target

### DIFF
--- a/src/VSSDK.BuildTools/Xamarin.VSSDK.BuildTools.GeneratePkgDef.targets
+++ b/src/VSSDK.BuildTools/Xamarin.VSSDK.BuildTools.GeneratePkgDef.targets
@@ -1,0 +1,40 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!--
+    ==================================================================================================================
+       Overrrides Generate Pkk Def (filtering the reference path to avoid the "filename or extension is too long" )
+    ==================================================================================================================
+  -->
+  <Target Name="GeneratePkgDef"
+          Inputs="$(TargetPath)"
+          Outputs="$(IntermediateOutputPath)$(TargetName).pkgdef"
+          Condition="'$(GeneratePkgDefFile)'=='true'"
+          DependsOnTargets="$(GeneratePkgDefDependsOn)">
+
+    <Message Text="Creating intermediate PkgDef file." />
+
+    <ItemGroup>
+      <_AssembliesToIncludeForBingding Include="@(ReferencePath)"
+        Condition="'%(ReferencePath.ResolvedFrom)' != 'ImplicitlyExpandDesignTimeFacades' and '%(ReferencePath.FrameworkFile)' != 'true'"  />
+    </ItemGroup>
+
+    <CreatePkgDef AssemblyToProcess="$(TargetPath)"
+                  ProductVersion="$(TargetVSVersion)"
+                  OutputFile="$(IntermediateOutputPath)$(TargetName).latest.pkgdef"
+                  UseCodebase="$(UseCodebase)"
+                  ReferencedAssemblies="@(_AssembliesToIncludeForBingding)"  />
+    <CopyIfChanged Condition="Exists('$(IntermediateOutputPath)$(TargetName).latest.pkgdef')"
+                   SourceFile="$(IntermediateOutputPath)$(TargetName).latest.pkgdef"
+                   DestinationFile="$(IntermediateOutputPath)$(TargetName).pkgdef" />
+
+    <!-- If the CTO file was changed, touch the pkgdef file to cause a re-merge -->
+    <Touch Files="$(IntermediateOutputPath)$(TargetName).pkgdef"
+           Condition="'$(CTOFileHasChanged)'=='true' AND Exists('$(IntermediateOutputPath)$(TargetName).pkgdef')" />
+
+    <ItemGroup>
+      <FileWrites Include="$(IntermediateOutputPath)$(TargetName).pkgdef" Condition="Exists('$(IntermediateOutputPath)$(TargetName).pkgdef')"/>
+      <FileWrites Include="$(IntermediateOutputPath)$(TargetName).latest.pkgdef" Condition="Exists('$(IntermediateOutputPath)$(TargetName).latest.pkgdef')"/>
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/VSSDK.BuildTools/Xamarin.VSSDK.BuildTools.targets
+++ b/src/VSSDK.BuildTools/Xamarin.VSSDK.BuildTools.targets
@@ -23,5 +23,6 @@
   <Import Project="Xamarin.VSSDK.BuildTools.FindSourceVsixManifest.targets" Condition="'$(OverrideDeployVsixExtensionFiles)' == 'true' and '$(Dev)' &gt;= '15.0'" />
   <Import Project="Xamarin.VSSDK.BuildTools.GetVsixDeploymentPath.targets" Condition="'$(OverrideDeployVsixExtensionFiles)' == 'true' and '$(Dev)' &gt;= '15.0'" />
   <Import Project="Xamarin.VSSDK.BuildTools.FindExistingDeploymentPath.targets" Condition="'$(OverrideDeployVsixExtensionFiles)' == 'true' and '$(Dev)' &gt;= '15.0'" />
+  <Import Project="Xamarin.VSSDK.BuildTools.GeneratePkgDef.targets" />
 
 </Project>

--- a/test/Xamarin.VSSDK.Tests/Builder.cs
+++ b/test/Xamarin.VSSDK.Tests/Builder.cs
@@ -31,7 +31,7 @@ public static partial class Builder
 
         using (var manager = new BuildManager(Guid.NewGuid().ToString()))
         {
-            var request = new BuildRequestData(project, targets.Split(','));
+            var request = new BuildRequestData(project, targets.Split(';'));
             var parameters = new BuildParameters
             {
                 GlobalProperties = properties,

--- a/test/Xamarin.VSSDK.Tests/GeneratePkgDefTests.cs
+++ b/test/Xamarin.VSSDK.Tests/GeneratePkgDefTests.cs
@@ -1,24 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
-using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Xamarin.VSSDK.Tests
 {
-    public class DeployVsixExtensionFilesTests : VsTest
+    public class GeneratePkgDefTests : VsTest
     {
         ITestOutputHelper output;
 
-        public DeployVsixExtensionFilesTests(ITestOutputHelper output) : base(output)
+        public GeneratePkgDefTests(ITestOutputHelper output) : base(output)
         { }
 
-        [Fact]
-        public void ExtensionFilesAreDeployedWhenBuidingExtension()
+        //[Fact]
+        public void PkgDefFileIsGeneratedWhenBuidingExtensionWithGeneratePkgDefFilePropertySet()
         {
             var vsixDeploymentPath = GetVsixDeploymentPath();
             if (!string.IsNullOrEmpty(vsixDeploymentPath) && Directory.Exists(vsixDeploymentPath))
@@ -32,16 +30,14 @@ namespace Xamarin.VSSDK.Tests
                 { "VSSDKTargetPlatformRegRootSuffix", RootSuffix },
             }, "15.0", new ProjectCollection());
 
-            var result = Builder.Build(project, "Restore;Build", output: output);
+            var result = Builder.Build(project, "Restore;Rebuild", output: output);
 
             Assert.Equal(BuildResultCode.Success, result.BuildResult.OverallResult);
 
             vsixDeploymentPath = GetVsixDeploymentPath();
 
             Assert.True(Directory.Exists(vsixDeploymentPath));
-            Assert.True(File.Exists(Path.Combine(vsixDeploymentPath, "VsixTemplate.dll")), "VsixTemplate.dll not found");
             Assert.True(File.Exists(Path.Combine(vsixDeploymentPath, "VsixTemplate.pkgdef")), "VsixTemplate.pkgdef not found");
-            Assert.True(File.Exists(Path.Combine(vsixDeploymentPath, "extension.vsixmanifest")), "extension.vsixmanifest found");
         }
     }
 }

--- a/test/Xamarin.VSSDK.Tests/Template.csproj
+++ b/test/Xamarin.VSSDK.Tests/Template.csproj
@@ -1,17 +1,21 @@
 ﻿<Project>
-	<Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
-	<PropertyGroup>
-		<IsCrossTargetingBuild Condition="'$(IsCrossTargetingBuild)' == '' and '$(TargetFrameworks)' != '' and '$(TargetFramework)' == ''">true</IsCrossTargetingBuild>
-		<SdkRootDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), .editorconfig))\src\VSSDK\bin\$(Configuration)\</SdkRootDir>
-	</PropertyGroup>
+  <PropertyGroup>
+    <IsCrossTargetingBuild Condition="'$(IsCrossTargetingBuild)' == '' and '$(TargetFrameworks)' != '' and '$(TargetFramework)' == ''">true</IsCrossTargetingBuild>
+    <SdkRootDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), .editorconfig))\src\VSSDK\bin\$(Configuration)\</SdkRootDir>
+  </PropertyGroup>
 
-	<Import Project="$(SdkRootDir)buildMultiTargeting\Xamarin.VSSDK.props" Condition="'$(IsCrossTargetingBuild)' == 'true'" />
-	<Import Project="$(SdkRootDir)build\Xamarin.VSSDK.props" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
+  <Import Project="$(SdkRootDir)buildMultiTargeting\Xamarin.VSSDK.props" Condition="'$(IsCrossTargetingBuild)' == 'true'" />
+  <Import Project="$(SdkRootDir)build\Xamarin.VSSDK.props" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
 
-	<ItemGroup Label="Test" />
+  <ItemGroup Label="Test" />
 
-	<Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
-	<Import Project="$(SdkRootDir)buildMultiTargeting\Xamarin.VSSDK.targets" Condition="'$(IsCrossTargetingBuild)' == 'true'" />
-	<Import Project="$(SdkRootDir)build\Xamarin.VSSDK.targets" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
+  <ItemGroup>
+    <Compile Remove="*.cs" />
+  </ItemGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="$(SdkRootDir)buildMultiTargeting\Xamarin.VSSDK.targets" Condition="'$(IsCrossTargetingBuild)' == 'true'" />
+  <Import Project="$(SdkRootDir)build\Xamarin.VSSDK.targets" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
 </Project>

--- a/test/Xamarin.VSSDK.Tests/VsTest.cs
+++ b/test/Xamarin.VSSDK.Tests/VsTest.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Linq;
+using Xunit.Abstractions;
+
+namespace Xamarin.VSSDK.Tests
+{
+    public class VsTest
+    {
+#if Dev14
+        const string BaseRootSuffix = "XamarinVSSDK_Tests14.0_";
+#elif Dev15
+        const string BaseRootSuffix = "XamarinVSSDK_Tests15.0_";
+#elif Dev16
+        protected const string BaseRootSuffix = "XamarinVSSDK_Tests16.0_";
+#elif Dev17
+        const string BaseRootSuffix = "XamarinVSSDK_Tests17.0_";
+#endif
+
+#if Dev14
+        protected const string TargetFramework = "net461";
+#else
+        protected const string TargetFramework = "net462";
+#endif
+
+
+        ITestOutputHelper output;
+
+        public VsTest(ITestOutputHelper output)
+        {
+            this.output = output;
+
+#if Dev14
+            Environment.SetEnvironmentVariable("VsSDKToolsPath", Path.Combine(Directory.GetCurrentDirectory(), "bin"));
+#endif
+
+#if Dev15
+            Assembly
+                .LoadFrom("Microsoft.VisualStudio.Sdk.BuildTasks.15.0.dll")
+                .GetType("Microsoft.VisualStudio.Sdk.BuildTasks.FolderLocator")
+                .GetProperty("InstanceInstallationPath", BindingFlags.Static | BindingFlags.Public)
+                .SetValue(null, Environment.GetEnvironmentVariable("VSINSTALLDIR"));
+#endif
+        }
+
+        protected string RootSuffix => BaseRootSuffix;
+
+        string GetTargetInstancePath() =>
+            Directory
+                .EnumerateDirectories(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft", "VisualStudio"))
+                .FirstOrDefault(x => x.Contains(RootSuffix));
+
+        protected string GetVsixDeploymentPath()
+        {
+            var targetInstancePath = GetTargetInstancePath();
+            if (!string.IsNullOrEmpty(targetInstancePath))
+                return Path.Combine(targetInstancePath, "Extensions", "Xamarin", "Xamarin.VSSDK.Test", "1.0.0");
+
+            return null;
+        }
+    }
+}

--- a/test/Xamarin.VSSDK.Tests/VsixTemplate.csproj
+++ b/test/Xamarin.VSSDK.Tests/VsixTemplate.csproj
@@ -5,14 +5,19 @@
     <IsCrossTargetingBuild Condition="'$(IsCrossTargetingBuild)' == '' and '$(TargetFrameworks)' != '' and '$(TargetFramework)' == ''">true</IsCrossTargetingBuild>
     <SdkRootDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), .editorconfig))\src\VSSDK\bin\$(Configuration)\</SdkRootDir>
     <SdkToolsRootDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), .editorconfig))\src\VSSDK.BuildTools\bin\$(Configuration)\</SdkToolsRootDir>
-    <GeneratePkgDefFile>false</GeneratePkgDefFile>
 
     <VSSDKInstall>$(MSBuildThisFileDirectory)</VSSDKInstall>
     <VSSDKAssemblyFile Condition="'$(TargetFramework)' == 'net461'" >Microsoft.VsSDK.Build.Tasks.dll</VSSDKAssemblyFile>
     <VSSDKAssemblyFile Condition="'$(TargetFramework)' == 'net462'" >Microsoft.VisualStudio.Sdk.BuildTasks.15.0.dll</VSSDKAssemblyFile>
 
-    <DeployVSTemplates>false</DeployVSTemplates>
+    <GeneratePkgDefFile Condition="'$(GeneratePkgDefFile)' == ''">false</GeneratePkgDefFile>
+    <DeployVSTemplates Condition="'$(DeployVSTemplates)' == ''">false</DeployVSTemplates>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Shell.14.0" Version="14.3.25407" Condition="'$(TargetFramework)' == 'net461'" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.0.26606" Condition="'$(TargetFramework)' == 'net462'" />
+  </ItemGroup>
   
   <Import Project="$(SdkRootDir)buildMultiTargeting\Xamarin.VSSDK.props" Condition="'$(IsCrossTargetingBuild)' == 'true'" />
   <Import Project="$(SdkRootDir)build\Xamarin.VSSDK.props" Condition="'$(IsCrossTargetingBuild)' != 'true'" />

--- a/test/Xamarin.VSSDK.Tests/VsixTemplatePackage.cs
+++ b/test/Xamarin.VSSDK.Tests/VsixTemplatePackage.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.Shell;
+
+namespace VsixTemplate
+{
+	[Guid("01A7700B-4990-4C4D-821D-9C2591AB9D70")]
+	[PackageRegistration(UseManagedResourcesOnly = true)]
+	public sealed class VsixTemplatePackage : Package
+	{
+		protected override void Initialize()
+		{
+		}
+	}
+}

--- a/test/Xamarin.VSSDK.Tests/Xamarin.VSSDK.Tests.csproj
+++ b/test/Xamarin.VSSDK.Tests/Xamarin.VSSDK.Tests.csproj
@@ -19,10 +19,17 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="VsixTemplatePackage.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="VsixTemplate.csproj">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Template.csproj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="VsixTemplatePackage.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <ThisAssemblyProjectProperty Include="Configuration" />


### PR DESCRIPTION
In order to filter the unnecessary assembly references passed to GenPkgDef.exe to
avoid errors with max length path (probably common when using PackageReference)