### PR TITLE
Added ValidateVsixReferencedAssemblies task/target

### DIFF
--- a/src/VSSDK.BuildTools/Properties/Resources.Designer.cs
+++ b/src/VSSDK.BuildTools/Properties/Resources.Designer.cs
@@ -68,5 +68,14 @@ namespace Xamarin.VSSDK.Properties {
                 return ResourceManager.GetString("UpdateVsixManifest_XVS001", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The extension assembly &apos;{0}&apos; has a reference to &apos;{1}&apos; which could not be avalaible in VS {2}. If it&apos;s not the case, please add the reference to the ExcludeValidateVsixReferencedAssembly item in order to ignore this error in future builds..
+        /// </summary>
+        internal static string ValidateVsixReferencedAssemblies_XVS002 {
+            get {
+                return ResourceManager.GetString("ValidateVsixReferencedAssemblies_XVS002", resourceCulture);
+            }
+        }
     }
 }

--- a/src/VSSDK.BuildTools/Properties/Resources.resx
+++ b/src/VSSDK.BuildTools/Properties/Resources.resx
@@ -120,4 +120,7 @@
   <data name="UpdateVsixManifest_XVS001" xml:space="preserve">
     <value>Source VSIX file '{0}' not found.</value>
   </data>
+  <data name="ValidateVsixReferencedAssemblies_XVS002" xml:space="preserve">
+    <value>The extension assembly '{0}' has a reference to '{1}' which could not be avalaible in VS {2}. If it's not the case, please add the reference to the ExcludeValidateVsixReferencedAssembly item in order to ignore this error in future builds.</value>
+  </data>
 </root>

--- a/src/VSSDK.BuildTools/ValidateVsixReferencedAssemblies.cs
+++ b/src/VSSDK.BuildTools/ValidateVsixReferencedAssemblies.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xamarin.VSSDK.Properties;
+
+namespace Xamarin.VSSDK
+{
+    /// <summary>
+    /// Verifies if the vsix contains assembly references that might not be
+    /// supported by the target VS version
+    /// </summary>
+    public class ValidateVsixReferencedAssemblies : Task
+    {
+        readonly Func<string, IEnumerable<AssemblyName>> referencedAssembliesProvider;
+
+        [Required]
+        public string Dev { get; set; }
+
+        [Required]
+        public ITaskItem[] VsixSourceItems { get; set; }
+
+        [Required]
+        public ITaskItem[] ReferencedAssembliesToValidate { get; set; }
+
+        public ITaskItem[] ExcludeValidateReferencedAssemblies { get; set; }
+
+        public ValidateVsixReferencedAssemblies()
+            : this(assemblyFile => Assembly.ReflectionOnlyLoadFrom(assemblyFile).GetReferencedAssemblies())
+        { }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ValidateVsixReferencedAssemblies(
+            Func<string, IEnumerable<AssemblyName>> referencedAssembliesProvider) =>
+                this.referencedAssembliesProvider = referencedAssembliesProvider;
+
+        public override bool Execute()
+        {
+            var devVersion = Version.Parse(Dev);
+
+            if (ExcludeValidateReferencedAssemblies == null)
+                ExcludeValidateReferencedAssemblies = Array.Empty<ITaskItem>();
+
+            var assemblyFiles = VsixSourceItems
+                .Select(x => x.ItemSpec)
+                .Where(x => ".dll".Equals(Path.GetExtension(x), StringComparison.OrdinalIgnoreCase));
+
+            foreach (var assemblyFile in assemblyFiles)
+            {
+                try
+                {
+                    var conflicts = referencedAssembliesProvider(assemblyFile)
+                        .Where(x =>
+                            ShouldValidateAssemblyReference(x) &&
+                            x.Version.Major > devVersion.Major);
+
+                    foreach (var conflict in conflicts)
+                        Log.LogErrorCode(
+                            nameof(Strings.ValidateVsixReferencedAssemblies.XVS002),
+                            Strings.ValidateVsixReferencedAssemblies.XVS002(
+                                Path.GetFileNameWithoutExtension(assemblyFile),
+                                conflict.FullName,
+                                Dev));
+                }
+                catch (BadImageFormatException) { }
+                catch (FileLoadException) { }
+                catch (Exception ex)
+                {
+                    Log.LogWarningFromException(ex);
+                }
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        bool ShouldValidateAssemblyReference(AssemblyName reference) =>
+            ReferencedAssembliesToValidate.Any(x => reference.FullName.Contains(x.ItemSpec)) &&
+            !ExcludeValidateReferencedAssemblies.Any(x => reference.FullName.Contains(x.ItemSpec));
+    }
+}

--- a/src/VSSDK.BuildTools/Xamarin.VSSDK.BuildTools.ValidateVsixReferencedAssemblies.targets
+++ b/src/VSSDK.BuildTools/Xamarin.VSSDK.BuildTools.ValidateVsixReferencedAssemblies.targets
@@ -1,0 +1,40 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask TaskName="ValidateVsixReferencedAssemblies" AssemblyFile="Xamarin.VSSDK.BuildTools.dll" />
+
+  <PropertyGroup>
+    <ValidateVsixReferencedAssemblies Condition="'$(ValidateVsixReferencedAssemblies)' == ''" >true</ValidateVsixReferencedAssemblies>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <ValidateVsixPartsDependsOn>
+      $(ValidateVsixPartsDependsOn);
+      ValidateVsixReferencedAssemblies
+    </ValidateVsixPartsDependsOn>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ReferencedAssembliesToValidate Include="Microsoft;VisualStudio" />
+  </ItemGroup>
+
+  <!--
+    =================================================================================
+                          Validate Vsix Referenced Assemblies
+    =================================================================================
+
+    Verifies if the vsix contains assembly references that might not be  
+    supported by the target VS version
+  -->
+  <Target Name="ValidateVsixReferencedAssemblies"
+          Condition="'$(ValidateVsixReferencedAssemblies)' == 'true' and '@(VSIXSourceItem)' != ''"
+          DependsOnTargets="GetVsixSourceItems">
+
+    <ValidateVsixReferencedAssemblies
+        VsixSourceItems="@(VSIXSourceItem->Distinct())"
+        ReferencedAssembliesToValidate="@(ReferencedAssembliesToValidate)"
+        ExcludeValidateReferencedAssemblies="@(ExcludeValidateVsixReferencedAssembly)"
+        Dev="$(Dev)">
+    </ValidateVsixReferencedAssemblies>
+    
+  </Target>
+  
+</Project>

--- a/src/VSSDK.BuildTools/Xamarin.VSSDK.BuildTools.targets
+++ b/src/VSSDK.BuildTools/Xamarin.VSSDK.BuildTools.targets
@@ -13,6 +13,7 @@
   <Import Project="$(VsSDKInstall)\Microsoft.VSSDK.targets" Condition="'$(VsSDKInstall)' != ''" />
 
   <Import Project="Xamarin.VSSDK.BuildTools.VsixManifest.targets" />
+  <Import Project="Xamarin.VSSDK.BuildTools.ValidateVsixReferencedAssemblies.targets" />
   <Import Project="Xamarin.VSSDK.BuildTools.VSSDKVersion.targets" />
 
   <PropertyGroup>

--- a/test/Xamarin.VSSDK.Tests/ValidateVsixReferencedAssembliesTests.cs
+++ b/test/Xamarin.VSSDK.Tests/ValidateVsixReferencedAssembliesTests.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Xamarin.VSSDK.Tests
+{
+    public class ValidateVsixReferencedAssembliesTests
+    {
+        ITestOutputHelper output;
+
+        public ValidateVsixReferencedAssembliesTests(ITestOutputHelper output) =>
+            this.output = output;
+
+        [Fact]
+        public void when_targeting_dev14_and_shell_15_is_referenced_then_fails()
+        {
+            var task = CreateTask();
+            task.Dev = "14.0";
+            task.VsixSourceItems = GetTaskItems("Foo.dll", "Foo.txt");
+            task.ReferencedAssembliesToValidate = GetTaskItems("Shell");
+
+            Assert.False(task.Execute());
+        }
+
+        [Fact]
+        public void when_targeting_dev15_and_shell_15_is_referenced_then_succeeds()
+        {
+            var task = CreateTask();
+            task.Dev = "15.0";
+            task.VsixSourceItems = GetTaskItems("Foo.dll", "Foo.txt");
+            task.ReferencedAssembliesToValidate = GetTaskItems("Shell");
+
+            Assert.True(task.Execute());
+        }
+
+        [Fact]
+        public void when_targeting_dev14_and_shell_is_not_validated_then_succeeds()
+        {
+            var task = CreateTask();
+            task.Dev = "14.0";
+            task.VsixSourceItems = GetTaskItems("Foo.dll", "Foo.txt");
+            // FooRef is not included to be validated
+            task.ReferencedAssembliesToValidate = GetTaskItems("Editor");
+
+            Assert.True(task.Execute());
+        }
+
+        [Fact]
+        public void when_targeting_dev14_and_shell_15_is_explicitly_excluded_then_succeeds()
+        {
+            var task = CreateTask();
+            task.Dev = "14.0";
+            task.VsixSourceItems = GetTaskItems("Foo.dll", "Foo.txt");
+            task.ReferencedAssembliesToValidate = GetTaskItems("Shell");
+            task.ExcludeValidateReferencedAssemblies = GetTaskItems("Shell.15");
+
+            Assert.True(task.Execute());
+        }
+
+        ITaskItem[] GetTaskItems(params string[] values) =>
+            values.Select(x => new TaskItem(x)).ToArray();
+
+        ValidateVsixReferencedAssemblies CreateTask() =>
+            new ValidateVsixReferencedAssemblies(x =>
+            {
+                if (x == "Foo.dll")
+                    return new AssemblyName[]
+                    {
+                        new AssemblyName("Shell.14.dll") { Version = new Version("14.0") },
+                        new AssemblyName("Shell.15.dll") { Version = new Version("15.0") }
+                    };
+
+                return Enumerable.Empty<AssemblyName>();
+            })
+            {
+                BuildEngine = new MockBuildEngine(output)
+            };
+    }
+}


### PR DESCRIPTION
Which verifies if the vsix contains assembly references that
might not be supported by the target VS version. e.g. An extension
targeting dev14 and referencing VS nuget packages with version 15.0

The target is scheduled via ValidateVsixPartsDependsOn (built-in
in the MS.VSSDK) which it's only executed if the VSIX container is
being created ('$(CreateVsixContainer)' == 'true')

By default "Microsoft;VisualStudio" string contains based references are evaluated.
But they can be customized via the ReferencedAssembliesToValidate or
ExcludeValidateVsixReferencedAssembly items.