### PR TITLE
Add support for generating binding redirects

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,5 +15,8 @@
 
     <!-- Build -->
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <SkipGitCache>true</SkipGitCache>
+    <SkipWriteGitCache>true</SkipWriteGitCache>
+    <SkipReadGitCache>true</SkipReadGitCache>
   </PropertyGroup>
 </Project>

--- a/src/VSSDK.BuildTools/Xamarin.VSSDK.BuildTools.GenerateBindingRedirects.targets
+++ b/src/VSSDK.BuildTools/Xamarin.VSSDK.BuildTools.GenerateBindingRedirects.targets
@@ -1,0 +1,190 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- This targets file automatically generates a BindingRedirects.pkgdef that 
+       provides fusion binding redirects for assemblies whose %(FusionName) metadata 
+       matches the specified @(BindingRedirect) identity/spec (evaluated as a regex), 
+       using the provided %(From) and %(To) metadata for the old version range to 
+       redirect to the matching referenced assemblies' current version. 
+       
+       Old version %(From) is optional and defaults to 0.0.0.0.
+       Old version %(To) is optional and defaults to the referenced assembly, 
+       unless $(BindingRedirectAllVersions) is 'true', in which case it defaults
+       to 99.9.9.9 (use with care, you may be downgrading assemblies).
+       
+       Examples:
+       
+       <ItemGroup>
+         <BindingRedirected Include="Newtonsoft.Json" />
+         <BindingRedirected Include="Octokit.+" From="0.28.0.0" />
+       </ItemGroup>
+  -->
+
+  <PropertyGroup>
+    <!-- If specified, the redirected max version will be 99.9.9.9 by default. 
+         Can be overriden for specific references by adding %(BindingRedirected.To) metadata.
+			   If 'false' (the defautl), the determined fusion version of the resolved @(ReferencePath) will 
+         be used instead. -->
+    <BindingRedirectAllVersions Condition="'$(BindingRedirectAllVersions)' == ''">false</BindingRedirectAllVersions>
+
+    <_BindingRedirects>BindingRedirects.pkgdef</_BindingRedirects>
+    <_GenerateBindingRedirects Condition="'$(BindingRedirectFusionExpr)' != ''">true</_GenerateBindingRedirects>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(_GenerateBindingRedirects)' == 'true'">
+    <GetCopyToOutputDirectoryItemsDependsOn>
+      BindingRedirects;
+      $(GetCopyToOutputDirectoryItemsDependsOn)
+    </GetCopyToOutputDirectoryItemsDependsOn>
+    <ResolveReferencesDependsOn>
+      $(ResolveReferencesDependsOn);
+      BindingRedirects
+    </ResolveReferencesDependsOn>
+    <BuildDependsOn Condition="'$(Configuration)' == 'Release'">
+      $(BuildDependsOn);
+      ReportBindingRedirects
+    </BuildDependsOn>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(_GenerateBindingRedirects)' == 'true'">
+    <Content Include="$(IntermediateOutputPath)$(_BindingRedirects)">
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>$(BindingRedirects)</Link>
+      <Visible>false</Visible>
+    </Content>
+  </ItemGroup>
+
+  <ItemDefinitionGroup>
+    <!-- Facade assemblies don't have this metadata attribute, so default it to empty -->
+    <ReferencePath>
+      <FusionName />
+    </ReferencePath>
+  </ItemDefinitionGroup>
+
+
+  <!--
+    =================================================================================
+    Generates the required binding redirects for the matching resolved references.
+    =================================================================================
+  -->
+  <Target Name="BindingRedirects" DependsOnTargets="$(BindingRedirectsDependsOn)" />
+
+  <PropertyGroup>
+    <BindingRedirectsDependsOn>
+      _CollectBindingRedirected;
+      _CleanBindingRedirectsPackage;
+      _GenerateBindingRedirectsPackage
+    </BindingRedirectsDependsOn>
+  </PropertyGroup>
+
+  <!--
+    =================================================================================
+    Reports the generated binding redirects
+    =================================================================================
+  -->
+  <Target Name="ReportBindingRedirects" DependsOnTargets="BindingRedirects">
+
+    <Message Text="Binding redirection applied for @(BindingRedirected -> Count()) assemblies"
+             Condition="@(BindingRedirected -> Count()) != 0"
+             Importance="high" />
+    <Message Text="    - %(BindingRedirected.Filename)%(BindingRedirected.Extension)" 
+             Condition="@(BindingRedirected -> Count()) != 0" 
+             Importance="normal" />
+
+  </Target>
+
+  <Target Name="_CollectBindingRedirected"
+          Inputs="@(BindingRedirected)"
+          Outputs="%(Identity)-BATCH"
+          DependsOnTargets="ResolveAssemblyReferences"
+          Returns="@(BindingRedirected)">
+
+    <PropertyGroup>
+      <_FusionExpression>%(BindingRedirected.Identity)</_FusionExpression>
+      <_OldFrom>%(BindingRedirected.From)</_OldFrom>
+      <_OldTo>%(BindingRedirected.To)</_OldTo>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_BindingRedirectedReference Include="@(ReferencePath)"
+                                   Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('%(ReferencePath.FusionName)', '$(_FusionExpression)', RegexOptions.IgnoreCase))" />
+      <_BindingRedirected Include="@(_BindingRedirectedReference -> Distinct())" />
+    </ItemGroup>
+
+    <Error Condition="'@(_BindingRedirected)' == ''" Text="No assembly references match the specified binding redirect expression '$(_FusionExpression)'." />
+
+    <ItemGroup>
+      <BindingRedirected Remove="@(BindingRedirected)" />
+      <BindingRedirected Include="@(_BindingRedirected)">
+        <From>$(_OldFrom)</From>
+        <To>$(_OldTo)</To>
+      </BindingRedirected>
+      <BindingRedirected Update="@(_BindingRedirected)">
+        <From Condition="'%(From)' == ''">0.0.0.0</From>
+        <To Condition="'%(To)' == '' And '$(BindingRedirectAllVersions)' == 'true'">99.9.9.9</To>
+        <To Condition="'%(To)' == '' And '$(BindingRedirectAllVersions)' != 'true'">%(Version)</To>
+      </BindingRedirected>
+    </ItemGroup>
+
+  </Target>
+
+  <Target Name="_CleanBindingRedirectsPackage"
+          Inputs="@(ReferencePath);$(MSBuildThisFileFullPath);$(MSBuildProjectFullPath)"
+          Outputs="$(IntermediateOutputPath)$(_BindingRedirects)">
+
+    <!-- If we're in this target, it's because the file is out of date, or it doesn't exist -->
+    <Delete Files="$(IntermediateOutputPath)$(_BindingRedirects)"
+            Condition="Exists('$(IntermediateOutputPath)$(_BindingRedirects)')" />
+
+  </Target>
+
+  <Target Name="_GenerateBindingRedirectsPackage"
+          DependsOnTargets="_CollectBindingRedirected"
+          Inputs="@(BindingRedirected)"
+          Outputs="%(Identity)-BATCH">
+
+    <PropertyGroup>
+      <_FusionName>%(BindingRedirected.FusionName)</_FusionName>
+      <_IsStrongNamed Condition="$(_FusionName.IndexOf(',')) != '-1'">true</_IsStrongNamed>
+    </PropertyGroup>
+
+    <!-- There is no need to redirect assemblies that don't have a strong name -->
+    <PropertyGroup Condition="'$(_IsStrongNamed)' == 'true'">
+      <_Name>$(_FusionName.Substring(0, $(_FusionName.IndexOf(','))))</_Name>
+      <_IndexOfToken>$(_FusionName.IndexOf('PublicKeyToken='))</_IndexOfToken>
+      <_IndexOfToken>$([MSBuild]::Add($(_IndexOfToken), 15))</_IndexOfToken>
+      <_Token>$(_FusionName.Substring($(_IndexOfToken)))</_Token>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(_IsStrongNamed)' == 'true'">
+      <BindingRedirected Update="@(BindingRedirected)">
+        <!-- The registry entries need a Guid, but it doesn't need to be preserved -->
+        <Guid>$([System.Guid]::NewGuid().ToString().ToUpper())</Guid>
+        <AssemblyName>$(_Name)</AssemblyName>
+        <PublicKeyToken>$(_Token)</PublicKeyToken>
+      </BindingRedirected>
+    </ItemGroup>
+
+    <MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" />
+    
+    <!-- NOTE: since we clear the existing out of date file in _CleanBindingRedirectsPackage, we don't overwrite on every entry here. -->
+    <WriteLinesToFile File="$(IntermediateOutputPath)$(_BindingRedirects)"
+                      Overwrite="false"
+                      Condition="'$(_IsStrongNamed)' == 'true' And '%(BindingRedirected.PublicKeyToken)' != 'null'"
+                      Lines='[$RootKey$\RuntimeConfiguration\dependentAssembly\bindingRedirection\{%(BindingRedirected.Guid)}]
+"name"="%(BindingRedirected.AssemblyName)"
+"publicKeyToken"="%(BindingRedirected.PublicKeyToken)"
+"culture"="neutral"
+"oldVersion"="%(BindingRedirected.From)-%(BindingRedirected.To)"
+"newVersion"="%(BindingRedirected.Version)"
+"codeBase"="$PackageFolder$\%(BindingRedirected.Filename)%(BindingRedirected.Extension)"
+
+'/>
+
+    <ItemGroup>
+      <FileWrites Include="$(IntermediateOutputPath)$(_BindingRedirects)" />
+    </ItemGroup>
+  </Target>
+
+
+</Project>

--- a/src/VSSDK.BuildTools/Xamarin.VSSDK.BuildTools.targets
+++ b/src/VSSDK.BuildTools/Xamarin.VSSDK.BuildTools.targets
@@ -25,6 +25,7 @@
   <Import Project="Xamarin.VSSDK.BuildTools.GetVsixDeploymentPath.targets" Condition="'$(OverrideDeployVsixExtensionFiles)' == 'true' and '$(Dev)' &gt;= '15.0'" />
   <Import Project="Xamarin.VSSDK.BuildTools.FindExistingDeploymentPath.targets" Condition="'$(OverrideDeployVsixExtensionFiles)' == 'true' and '$(Dev)' &gt;= '15.0'" />
   <Import Project="Xamarin.VSSDK.BuildTools.GeneratePkgDef.targets" />
+  <Import Project="Xamarin.VSSDK.BuildTools.GenerateBindingRedirects.targets" />
 
   <!-- This fixes the GetVsixSourceItems target when the project references are being evaluated in a cross targeting build -->
   <Target Name="AppendTargetFrameworkToProjectReferencesWithConfiguration" Inputs="@(_MSBuildProjectReferenceExistent)" Outputs="%(_MSBuildProjectReferenceExistent.Identity)-BATCH" AfterTargets="PrepareProjectReferences" Returns="@(ProjectReferenceWithConfiguration)">

--- a/src/VSSDK.BuildTools/buildMultiTargeting/Xamarin.VSSDK.BuildTools.targets
+++ b/src/VSSDK.BuildTools/buildMultiTargeting/Xamarin.VSSDK.BuildTools.targets
@@ -1,0 +1,33 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!--
+	============================================================
+                      CreateVsixContainer
+   Cross-targeting version of CreateVsixContainer. 
+   NOTE: depends on Microsoft.Common.CrossTargeting.targets
+   
+   [OUT]
+   @(InnerOutput) - The combined output items of the inner targets across
+                    all builds.
+  ============================================================
+  -->
+  <Target Name="CreateVsixContainer" DependsOnTargets="_SetCreateVsixContainerInnerTarget;DispatchToInnerBuilds" Returns="@(InnerOutput)" />
+
+  <Target Name="_SetCreateVsixContainerInnerTarget">
+    <PropertyGroup>
+      <InnerTargets>CreateVsixContainer</InnerTargets>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="_AddCreateVsixExtrension" BeforeTargets="DispatchToInnerBuilds">
+    <PropertyGroup>
+      <CreateVsixContainer Condition="'$(CreateVsixContainer)' == ''">true</CreateVsixContainer>
+    </PropertyGroup>
+    <ItemGroup>
+      <_InnerBuildProjects>
+        <AdditionalProperties>%(AdditionalProperties);CreateVsixContainer=$(CreateVsixContainer)</AdditionalProperties>
+      </_InnerBuildProjects>
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/test/Xamarin.VSSDK.Tests/BindRedirected.csproj
+++ b/test/Xamarin.VSSDK.Tests/BindRedirected.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <TargetFramework>net461</TargetFramework>
+    
+    <ToolsRootDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), .editorconfig))\src\VSSDK.BuildTools\</ToolsRootDir>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="automapper" Version="6.2.2" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <!-- Causes default old version from to be 99.9.9.9 -->
+    <BindingRedirectAllVersions>true</BindingRedirectAllVersions>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <BindingRedirected Include="Newtonsoft.Json">
+      <!-- Showcases specifying only From metadata -->
+      <From>6.0.0.0</From>
+    </BindingRedirected>
+    <!-- Showcases specifying no From/To metadata at all, and case-insensitive matching -->
+    <BindingRedirected Include="automapper" />
+    <!-- Showcases matching a specific assembly -->
+    <BindingRedirected Include="^System, Version=4.0.0.0" From="2.0.0.0" />
+    <!-- Showcases matching with a regex that matches two assemblies -->
+    <BindingRedirected Include="System.Xml+" From="3.0.0.0" />
+  </ItemGroup>
+
+  <Import Project="$(NuGetRestoreTargets)" Condition="'$(NuGetRestoreTargets)' != '' and '$(IsRestoreTargetsFileLoaded)' != 'true'" />
+  <Import Project="$(ToolsRootDir)Xamarin.VSSDK.BuildTools.GenerateBindingRedirects.targets" />
+</Project>

--- a/test/Xamarin.VSSDK.Tests/GenerateBindingRedirectsTests.cs
+++ b/test/Xamarin.VSSDK.Tests/GenerateBindingRedirectsTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Xamarin.VSSDK.Tests
+{
+    public class GenerateBindingRedirectsTests : VsTest
+    {
+        // This resolves the SDKs to the same location that was used to compile this project.
+        static GenerateBindingRedirectsTests() => Environment.SetEnvironmentVariable(
+            nameof(ThisAssembly.Project.Properties.MSBuildSDKsPath),
+            ThisAssembly.Project.Properties.MSBuildSDKsPath);
+
+        public GenerateBindingRedirectsTests(ITestOutputHelper output) : base(output) { }
+
+        //[InlineData("net461")]
+        //[InlineData("net462")]
+        //[Theory(Skip = "Can't make this work yet")]
+        [Fact]
+        public void BindingRedirectsCanBeProvided()
+        {
+            Func<ProjectInstance> factory = () => new ProjectInstance("BindRedirected.csproj", new Dictionary<string, string>
+            {
+                { "TargetFramework", "net461" },
+                { "Configuration", ThisAssembly.Project.Properties.Configuration },
+                { nameof(ThisAssembly.Project.Properties.MSBuildExtensionsPath), ThisAssembly.Project.Properties.MSBuildExtensionsPath },
+                { nameof(ThisAssembly.Project.Properties.NuGetRestoreTargets), ThisAssembly.Project.Properties.NuGetRestoreTargets },
+                { nameof(ThisAssembly.Project.Properties.CSharpCoreTargetsPath), ThisAssembly.Project.Properties.CSharpCoreTargetsPath },
+                { nameof(ThisAssembly.Project.Properties.RoslynTargetsPath), ThisAssembly.Project.Properties.RoslynTargetsPath },
+            }, "15.0", new ProjectCollection());
+
+            var result = Builder.Build(factory(), "Restore").AssertSuccess();
+            result = Builder.Build(factory(), "ReportBindingRedirects").AssertSuccess();
+        }
+    }
+}

--- a/test/Xamarin.VSSDK.Tests/GeneratePkgDefTests.cs
+++ b/test/Xamarin.VSSDK.Tests/GeneratePkgDefTests.cs
@@ -10,10 +10,7 @@ namespace Xamarin.VSSDK.Tests
 {
     public class GeneratePkgDefTests : VsTest
     {
-        ITestOutputHelper output;
-
-        public GeneratePkgDefTests(ITestOutputHelper output) : base(output)
-        { }
+        public GeneratePkgDefTests(ITestOutputHelper output) : base(output) { }
 
         //[Fact]
         public void PkgDefFileIsGeneratedWhenBuidingExtensionWithGeneratePkgDefFilePropertySet()
@@ -30,7 +27,7 @@ namespace Xamarin.VSSDK.Tests
                 { "VSSDKTargetPlatformRegRootSuffix", RootSuffix },
             }, "15.0", new ProjectCollection());
 
-            var result = Builder.Build(project, "Restore;Rebuild", output: output);
+            var result = Builder.Build(project, "Restore;Rebuild", output: Output);
 
             Assert.Equal(BuildResultCode.Success, result.BuildResult.OverallResult);
 

--- a/test/Xamarin.VSSDK.Tests/Xamarin.VSSDK.Tests.csproj
+++ b/test/Xamarin.VSSDK.Tests/Xamarin.VSSDK.Tests.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="BindRedirected.csproj" />
     <None Include="VsixTemplate.csproj">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -82,6 +83,10 @@
   <ItemGroup>
     <None Update="source.extension.vsixmanifest">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="BindRedirected.csproj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>$([MSBuild]::ValueOrDefault('%(None.NuGetPackageId)', '').Equals(''))</Visible>
     </None>
   </ItemGroup>
 


### PR DESCRIPTION
Usage examples:

```
    <BindingRedirected Include="Newtonsoft.Json">
      <!-- Showcases specifying only From metadata -->
      <From>6.0.0.0</From>
    </BindingRedirected>
    <!-- Showcases specifying no From/To metadata at all -->
    <BindingRedirected Include="AutoMapper" />
    <!-- Showcases matching a specific assembly -->
    <BindingRedirected Include="^System, Version=4.0.0.0" From="2.0.0.0" />
    <!-- Showcases matching with a regex that matches two assemblies -->
    <BindingRedirected Include="System.Xml.+" From="3.0.0.0" />
```

The only configurable property is:

```
  <PropertyGroup>
    <!-- Causes default old version from to be 99.9.9.9 -->
    <BindingRedirectAllVersions>true</BindingRedirectAllVersions>
  </PropertyGroup>
```

Pending some tests, but manual testing verified.