### PR TITLE
Push to xamarin-impl feed

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -59,3 +59,26 @@ steps:
     PathtoPublish: $(Build.ArtifactStagingDirectory)
     ArtifactName: output
     ArtifactType: Container
+
+- task: NuGetCommand@2
+  displayName: 'NuGet Update'
+  inputs:
+    command: custom
+    arguments: 'update -self'
+
+- pwsh: |
+    $branch = '$(Build.SourceBranch)'
+    $push = "$($branch -eq 'refs/heads/master' -or $branch -match 'refs/heads/d\d\d-*|refs/heads/rel/*')".ToLowerInvariant()
+    Write-Host "##vso[task.setvariable variable=PushPackages;]$push"
+  displayName: Set PushPackages
+  condition: eq(variables['PushPackages'], '')
+   
+- task: NuGetCommand@2
+  displayName: Push Packages
+  continueOnError: true
+  condition: and(succeeded(), eq(variables['PushPackages'], 'true'))
+  inputs:
+    command: push
+    packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
+    nuGetFeedType: external
+    publishFeedCredentials: 'xamarin-impl public feed'


### PR DESCRIPTION
External consumers can use the existing `xamarin-impl` feed, configured with:

```
<add key="xamarin-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json" />
```

This feed will only contain master and release branch packages, making it the "official" feed.

For feature testing, dev and PR package validation, use the following feed instead, which contains everything:

```
<add key="xvs" value="https://nugetized.blob.core.windows.net/xvs/index.json" />
```