### PR TITLE
Switch over to keyvault backed variable

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -3,6 +3,7 @@ pool:
 
 variables:
 - group: Xamarin NuGetized
+- group: Xamarin-Nugetized-Secrets
 
 resources:
   repositories:
@@ -48,7 +49,7 @@ steps:
 
 - template: sleet/v1.yml@templates
   parameters:
-    connectionString: $(SLEET_FEED_CONNECTIONSTRING)
+    connectionString: $(sleet-connection-string)
     container: xvs
     packages: $(Build.ArtifactStagingDirectory)
 


### PR DESCRIPTION
The `SLEET_CONNECTION_FEED` variable referenced in this pipeline to the nugetized blob container has been compromised.

This migrates the current variable (in the [Xamarin Release](https://devdiv.visualstudio.com/DevDiv/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=17&path=Xamarin%20Release) group to a keyvault-backed variable group [Xamarin-Nugetized-Secrets](https://devdiv.visualstudio.com/DevDiv/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=349&path=Xamarin-Nugetized-Secrets) to facilitate the rotation of this credential.